### PR TITLE
chore: change references to CTD to TID instead

### DIFF
--- a/rfcs/0000-template.md
+++ b/rfcs/0000-template.md
@@ -58,7 +58,7 @@ Why should we *not* do this?
 Discuss prior art, both the good and the bad, in relation to this proposal. A few examples of what
 this can include are:
 
-- Can we learn something about this proposal from other projects in CTD?
+- Can we learn something about this proposal from other projects in TID?
 - Can we learn something about this proposal from other transit agencies?
 - Can we learn something about this proposal from past experiences in other jobs or projects?
 

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -3,7 +3,7 @@
 The RFC process here is inspired by [that of the Rust programming
 language](https://github.com/rust-lang/rfcs).
 
-The process is intended to provide CTD team members a venue in which to propose substantial
+The process is intended to provide TID team members a venue in which to propose substantial
 technical changes and refactors to this application. The RFC will be reviewed and merged as either
 accepted, meaning we commit to working on it at some point in the future, or rejected. The RFCs will
 remain in the repository and be a source of historical information for anyone looking back for
@@ -29,7 +29,7 @@ should change. Such changes may include:
 
 - A substantial refactor, which takes a developer roughly an entire sprint or more.
 - Public facing changes, which might need to be coordinated with other groups inside or outside of
-  CTD.
+  TID.
 
 Changes that don't need an RFC may be:
 


### PR DESCRIPTION
Leaves existing notes and RFCs as-is as I was less sure about modifying historical documents like those.