### PR TITLE
doc: Update naming convention for Terraform/OpenTofu

### DIFF
--- a/rfcs/accepted/0013-consistent-resource-names.md
+++ b/rfcs/accepted/0013-consistent-resource-names.md
@@ -36,8 +36,10 @@ We use the following patterns for resources:
 	- https://www.ssl.com/faqs/underscores-not-allowed-in-domain-names/
 - S3 buckets: kebab-case
 	- https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
-- Terraform names: snake_case
+- Terraform/OpenTofu resource, data source, and variable names: snake_case
         - https://www.terraform-best-practices.com/naming
+- Terraform/OpenTofu module names: kebab-case
+        - https://developer.hashicorp.com/terraform/registry/modules/publish#requirements
 - ECS clusters: kebab-case
 - ECS applications: kebab-case
 - ECR repositories: kebab-case

--- a/rfcs/accepted/0013-consistent-resource-names.md
+++ b/rfcs/accepted/0013-consistent-resource-names.md
@@ -38,7 +38,7 @@ We use the following patterns for resources:
 	- https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
 - Terraform/OpenTofu resource, data source, and variable names: snake_case
         - https://www.terraform-best-practices.com/naming
-- Terraform/OpenTofu module names: kebab-case
+- Terraform/OpenTofu module names (i.e. directory names in terraform_modules and devops/terraform): kebab-case
         - https://developer.hashicorp.com/terraform/registry/modules/publish#requirements
 - ECS clusters: kebab-case
 - ECS applications: kebab-case


### PR DESCRIPTION
- resources, data sources, and variables are `snake_case`
- module names are `kebab-case`

I tried to find an OpenTofu-specific documentation link for module names, but their [equivalent document](https://search.opentofu.org/docs/modules/publishing) is lacking in comprehensiveness.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210453394775902