### PR TITLE
chore: add Scalr and Keycloak conventions

### DIFF
--- a/rfcs/accepted/0013-consistent-resource-names.md
+++ b/rfcs/accepted/0013-consistent-resource-names.md
@@ -40,6 +40,9 @@ We use the following patterns for resources:
         - https://www.terraform-best-practices.com/naming
 - Terraform/OpenTofu module names (i.e. directory names in terraform_modules and devops/terraform): kebab-case
         - https://developer.hashicorp.com/terraform/registry/modules/publish#requirements
+- Scalr teams: snake_case
+- Keycloak clients: kebab-case
+- Keycloak roles: kebab-case
 - ECS clusters: kebab-case
 - ECS applications: kebab-case
 - ECR repositories: kebab-case

--- a/rfcs/accepted/0013-consistent-resource-names.md
+++ b/rfcs/accepted/0013-consistent-resource-names.md
@@ -41,8 +41,8 @@ We use the following patterns for resources:
 - Terraform/OpenTofu module names (i.e. directory names in terraform_modules and devops/terraform): kebab-case
         - https://developer.hashicorp.com/terraform/registry/modules/publish#requirements
 - Scalr teams: snake_case
+- Keycloak roles: kebab_case (to match corresponding Scalr teams)
 - Keycloak clients: kebab-case
-- Keycloak roles: kebab-case
 - ECS clusters: kebab-case
 - ECS applications: kebab-case
 - ECR repositories: kebab-case

--- a/rfcs/accepted/0013-consistent-resource-names.md
+++ b/rfcs/accepted/0013-consistent-resource-names.md
@@ -41,7 +41,7 @@ We use the following patterns for resources:
 - Terraform/OpenTofu module names (i.e. directory names in terraform_modules and devops/terraform): kebab-case
         - https://developer.hashicorp.com/terraform/registry/modules/publish#requirements
 - Scalr teams: snake_case
-- Keycloak roles: kebab_case (to match corresponding Scalr teams)
+- Keycloak roles: snake_case (to match corresponding Scalr teams)
 - Keycloak clients: kebab-case
 - ECS clusters: kebab-case
 - ECS applications: kebab-case


### PR DESCRIPTION
Asana task: [Update naming convention RFC to include Scalr teams and their corresponding Keycloak roles](https://app.asana.com/1/15492006741476/project/1113545750913664/task/1210318204318399?focus=true)

##Summary
This PR adds Scalr teams, Keycloak clients, and Keycloak roles to the naming conventions doc. 